### PR TITLE
Fix bug in max test time assertion

### DIFF
--- a/lib/minitest/speed.rb
+++ b/lib/minitest/speed.rb
@@ -46,7 +46,7 @@ module Minitest::Speed
     @teardown_t0 = Time.now
 
     delta = Time.now - @test_t0
-    assert_operator delta, :<=, @@max_teardown_time
+    assert_operator delta, :<=, @@max_test_time
   end
 
   def after_teardown # :nodoc:

--- a/test/test_minitest_speed.rb
+++ b/test/test_minitest_speed.rb
@@ -6,9 +6,9 @@ module TestMinitest; end
 class SpeedTest < Minitest::Test
   include Minitest::Speed
 
-  @@max_setup_time    = 0.01
-  @@max_test_time     = 0.01
-  @@max_teardown_time = 0.01
+  @@max_setup_time    = 0.05
+  @@max_test_time     = 0.15
+  @@max_teardown_time = 0.25
 
   def self.go(&b)
     Class.new(SpeedTest, &b).new(:test_something).run
@@ -16,12 +16,28 @@ class SpeedTest < Minitest::Test
 end
 
 class TestMinitest::TestSpeed < Minitest::Test
-  def assert_test_speed(&b)
+  def assert_slow(&b)
     refute_predicate SpeedTest.go(&b), :passed?
   end
 
+  def assert_fast(&b)
+    assert_predicate SpeedTest.go(&b), :passed?
+  end
+
+  def test_fast_setup
+    assert_fast do
+      def setup
+        sleep 0.01
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  end
+
   def test_slow_setup
-    assert_test_speed do
+    assert_slow do
       def setup
         sleep 0.1
       end
@@ -32,18 +48,38 @@ class TestMinitest::TestSpeed < Minitest::Test
     end
   end
 
-  def test_slow_test
-    assert_test_speed do
+  def test_fast_test
+    assert_fast do
       def test_something
         sleep 0.1
       end
     end
   end
 
-  def test_slow_teardown
-    assert_test_speed do
+  def test_slow_test
+    assert_slow do
+      def test_something
+        sleep 0.2
+      end
+    end
+  end
+
+  def test_fast_teardown
+    assert_fast do
       def teardown
-        sleep 0.1
+        sleep 0.2
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  end
+
+  def test_slow_teardown
+    assert_slow do
+      def teardown
+        sleep 0.3
       end
 
       def test_something


### PR DESCRIPTION
Max test time was asserted using the wrong value (that of `@@max_teardown_time`). Improved the tests by using different values for each class variable, and testing both "faster than" and "slower than" for setup, test and teardown.
