### PR TITLE
Allow for custom `clock_time`

### DIFF
--- a/lib/minitest/speed.rb
+++ b/lib/minitest/speed.rb
@@ -24,16 +24,30 @@ module Minitest::Speed
 
   @@max_teardown_time = 1.0
 
+  ##
+  # Default way of getting the current time.
+  # @@clock_time_method = proc { Minitest.clock_time }
+
+  mc = class << self; self; end
+
+  ##
+  # Default way of getting the current time.
+
+  mc.attr_accessor :clock_time_method
+
+  self.clock_time_method = -> { Minitest.clock_time }
+
+
   def before_setup # :nodoc:
     super
 
-    @setup_t0 = Minitest.clock_time
+    @setup_t0 = Minitest::Speed.clock_time_method.call
   end
 
   def after_setup # :nodoc:
-    delta = Minitest.clock_time - @setup_t0
+    delta = Minitest::Speed.clock_time_method.call - @setup_t0
 
-    @test_t0 = Minitest.clock_time
+    @test_t0 = Minitest::Speed.clock_time_method.call
 
     assert_operator delta, :<=, @@max_setup_time, "max_setup_time exceeded"
 
@@ -43,15 +57,15 @@ module Minitest::Speed
   def before_teardown # :nodoc:
     super
 
-    @teardown_t0 = Minitest.clock_time
+    @teardown_t0 = Minitest::Speed.clock_time_method.call
 
-    delta = Minitest.clock_time - @test_t0
+    delta = Minitest::Speed.clock_time_method.call - @test_t0
 
     assert_operator delta, :<=, @@max_test_time, "max_test_time exceeded"
   end
 
   def after_teardown # :nodoc:
-    delta = Minitest.clock_time - @teardown_t0
+    delta = Minitest::Speed.clock_time_method.call - @teardown_t0
 
     assert_operator delta, :<=, @@max_teardown_time, "max_teardown_time exceeded"
 

--- a/test/test_minitest_speed.rb
+++ b/test/test_minitest_speed.rb
@@ -87,4 +87,20 @@ class TestMinitest::TestSpeed < Minitest::Test
       end
     end
   end
+
+  def test_clock_time_method
+    clock_time_method_was = Minitest::Speed.clock_time_method
+    assert_fast do
+      Minitest::Speed.clock_time_method = proc { 0 }
+      def setup
+        sleep(0.03)
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  ensure
+    Minitest::Speed.clock_time_method = clock_time_method_was
+  end
 end


### PR DESCRIPTION
`Timecop` patches both methods `Minitest.clock_time` relies on (`Process.clock_gettime` and `Time.now`)[^1]. This can create misleading results. This PR makes the `clock_time` configurable. Pass it something callable and `minitest-speed` will use that instead. For example, set it to `proc {
Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC) }` to avoid `Timecop`'s `Process.clock_gettime` patch.

[^1]:(https://github.com/minitest/minitest/blob/d84437f874b42be1c3d46b81640904144fc7dac4/lib/minitest.rb#L1215-L1223)