### PR TITLE
Allow for disabling the speed checks

### DIFF
--- a/lib/minitest/speed.rb
+++ b/lib/minitest/speed.rb
@@ -49,7 +49,8 @@ module Minitest::Speed
 
     @test_t0 = Minitest::Speed.clock_time_method.call
 
-    assert_operator delta, :<=, @@max_setup_time, "max_setup_time exceeded"
+    assert_operator delta, :<=, @@max_setup_time, "max_setup_time exceeded" unless @permit_slow_setup
+    @permit_slow_setup = false
 
     super
   end
@@ -61,14 +62,37 @@ module Minitest::Speed
 
     delta = Minitest::Speed.clock_time_method.call - @test_t0
 
-    assert_operator delta, :<=, @@max_test_time, "max_test_time exceeded"
+    assert_operator delta, :<=, @@max_test_time, "max_test_time exceeded" unless @permit_slow_test
+    @permit_slow_test = false
   end
 
   def after_teardown # :nodoc:
     delta = Minitest::Speed.clock_time_method.call - @teardown_t0
 
-    assert_operator delta, :<=, @@max_teardown_time, "max_teardown_time exceeded"
+    assert_operator delta, :<=, @@max_teardown_time, "max_teardown_time exceeded" unless @permit_slow_teardown
+    @permit_slow_teardown = false
 
     super
+  end
+
+  ##
+  # Disable setup speed assertion for the current setup.
+
+  def permit_slow_setup
+    @permit_slow_setup = true
+  end
+
+  ##
+  # Disable test speed assertion for the current test.
+
+  def permit_slow_test
+    @permit_slow_test = true
+  end
+
+  ##
+  # Disable teardown speed assertion for the current teardown.
+
+  def permit_slow_teardown
+    @permit_slow_teardown = true
   end
 end

--- a/lib/minitest/speed.rb
+++ b/lib/minitest/speed.rb
@@ -24,16 +24,30 @@ module Minitest::Speed
 
   @@max_teardown_time = 1.0
 
+  ##
+  # Default way of getting the current time.
+  # @@clock_time_method = proc { Minitest.clock_time }
+
+  mc = class << self; self; end
+
+  ##
+  # Default way of getting the current time.
+
+  mc.attr_accessor :clock_time_method
+
+  self.clock_time_method = -> { Minitest.clock_time }
+
+
   def before_setup # :nodoc:
     super
 
-    @setup_t0 = Minitest.clock_time
+    @setup_t0 = Minitest::Speed.clock_time_method.call
   end
 
   def after_setup # :nodoc:
-    delta = Minitest.clock_time - @setup_t0
+    delta = Minitest::Speed.clock_time_method.call - @setup_t0
 
-    @test_t0 = Minitest.clock_time
+    @test_t0 = Minitest::Speed.clock_time_method.call
 
     assert_operator delta, :<=, @@max_setup_time, "max_setup_time exceeded"
 
@@ -43,15 +57,15 @@ module Minitest::Speed
   def before_teardown # :nodoc:
     super
 
-    @teardown_t0 = Minitest.clock_time
+    @teardown_t0 = Minitest::Speed.clock_time_method.call
 
-    delta = Minitest.clock_time - @test_t0
+    delta = Minitest::Speed.clock_time_method.call - @test_t0
 
     assert_operator delta, :<=, @@max_test_time, "max_test_time exceeded"
   end
 
   def after_teardown # :nodoc:
-    delta = Minitest.clock_time - @teardown_t0
+    delta = Minitest::Speed.clock_time_method.call - @teardown_t0
 
     assert_operator delta, :<=, @@max_teardown_time, "max_teardown_time exceeded"
 

--- a/test/test_minitest_speed.rb
+++ b/test/test_minitest_speed.rb
@@ -87,4 +87,20 @@ class TestMinitest::TestSpeed < Minitest::Test
       end
     end
   end
+
+  def test_clock_time_method
+    clock_time_method_was = Minitest::Speed.clock_time_method
+    assert_fast do
+      Minitest::Speed.clock_time_method = proc { 0 }
+      def setup
+        sleep(0.03)
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  ensure
+    Minitest::Speed.clock_time_method = clock_time_method_was
+  end
 end

--- a/test/test_minitest_speed.rb
+++ b/test/test_minitest_speed.rb
@@ -48,6 +48,19 @@ class TestMinitest::TestSpeed < Minitest::Test
     end
   end
 
+  def test_permit_slow_setup
+    assert_fast do
+      def setup
+        permit_slow_setup
+        sleep 0.01
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  end
+
   def test_fast_test
     assert_fast do
       def test_something
@@ -59,6 +72,15 @@ class TestMinitest::TestSpeed < Minitest::Test
   def test_slow_test
     assert_slow do
       def test_something
+        sleep 0.02
+      end
+    end
+  end
+
+  def test_permit_slow_test
+    assert_fast do
+      def test_something
+        permit_slow_test
         sleep 0.02
       end
     end
@@ -79,6 +101,19 @@ class TestMinitest::TestSpeed < Minitest::Test
   def test_slow_teardown
     assert_slow do
       def teardown
+        sleep 0.03
+      end
+
+      def test_something
+        assert true
+      end
+    end
+  end
+
+  def test_permit_slow_teardown
+    assert_fast do
+      def teardown
+        permit_slow_teardown
         sleep 0.03
       end
 


### PR DESCRIPTION
Adds 3 methods:

- `#permit_slow_setup` to allow the current setup to pass, even if it
exceeds @@max_setup_time.
- `#permit_slow_test` to allow the current test to pass, even if it
exceeds @@max_test_time.
- `#permit_slow_teardown` to allow the current teardown to pass, even if it
exceeds @@max_teardown_time.